### PR TITLE
fix: conditionally style based on readOnly access, correctly passthrough ref + onFocus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
+        "@reach/auto-id": "^0.13.2",
         "react-markdown": "^5.0.3",
         "react-mde": "^11.5.0",
         "remark-gfm": "^1.0.0"
@@ -1955,7 +1956,6 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.13.2.tgz",
       "integrity": "sha512-dWeXt6xxjN+NPRoZFXgmNkF89t8MEPsWLYjIIDf3gNXA/Dxaoytc9YBOIfVGpDSpdOwxPpxOu8rH+4Y3Jk2gHA==",
-      "peer": true,
       "dependencies": {
         "@reach/utils": "0.13.2",
         "tslib": "^2.1.0"
@@ -1969,7 +1969,6 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.13.2.tgz",
       "integrity": "sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==",
-      "peer": true,
       "dependencies": {
         "@types/warning": "^3.0.0",
         "tslib": "^2.1.0",
@@ -2547,8 +2546,7 @@
     "node_modules/@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=",
-      "peer": true
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -8113,7 +8111,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -9576,7 +9573,6 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.13.2.tgz",
       "integrity": "sha512-dWeXt6xxjN+NPRoZFXgmNkF89t8MEPsWLYjIIDf3gNXA/Dxaoytc9YBOIfVGpDSpdOwxPpxOu8rH+4Y3Jk2gHA==",
-      "peer": true,
       "requires": {
         "@reach/utils": "0.13.2",
         "tslib": "^2.1.0"
@@ -9586,7 +9582,6 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.13.2.tgz",
       "integrity": "sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==",
-      "peer": true,
       "requires": {
         "@types/warning": "^3.0.0",
         "tslib": "^2.1.0",
@@ -10105,8 +10100,7 @@
     "@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=",
-      "peer": true
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "acorn": {
       "version": "7.4.1",
@@ -14270,7 +14264,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "dependencies": {
+    "@reach/auto-id": "^0.13.2",
     "react-markdown": "^5.0.3",
     "react-mde": "^11.5.0",
     "remark-gfm": "^1.0.0"

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import ReactMde from 'react-mde'
 import ReactMarkdown from 'react-markdown'
 import gfm from 'remark-gfm'
+import {useId} from '@reach/auto-id'
 
 import PatchEvent, {set, unset} from 'part:@sanity/form-builder/patch-event'
 import sanityClient from 'part:@sanity/base/client'
@@ -22,11 +23,21 @@ const defaultToolbarCommands = [
 ]
 
 export default React.forwardRef(function MarkdownEditor(props, ref) {
-  const {type, value = '', markers, presence, readOnly} = props
+  const {type, value = '', markers, onBlur, onChange, onFocus, presence, readOnly} = props
   const {options = {}} = type
   const [selectedTab, setSelectedTab] = React.useState('write')
   const [editedValue, setEditedValue] = React.useState(value)
   const debouncedValue = useDebounce(editedValue, 100)
+  const textarea = React.useRef()
+
+  // Conditionally update textarea styles based on read only access.
+  // It's also possible to define inline styles via `childProps.textArea.style` on `<ReactMde />`,
+  // but this will override any dynamically created styles provided by the component itself.
+  React.useEffect(() => {
+    if (textarea.current) {
+      textarea.current.style.backgroundColor = readOnly ? 'rgba(240,240,240)' : 'rgba(255,255,255)'
+    }
+  }, [textarea])
 
   React.useEffect(() => {
     setEditedValue(value)
@@ -34,9 +45,9 @@ export default React.forwardRef(function MarkdownEditor(props, ref) {
 
   React.useEffect(() => {
     if (!debouncedValue && value) {
-      props.onChange(PatchEvent.from([unset()]))
+      onChange(PatchEvent.from([unset()]))
     } else if (debouncedValue !== value) {
-      props.onChange(PatchEvent.from([set(debouncedValue)]))
+      onChange(PatchEvent.from([set(debouncedValue)]))
     }
   }, [debouncedValue])
 
@@ -56,29 +67,47 @@ export default React.forwardRef(function MarkdownEditor(props, ref) {
     return success
   }
 
+  // Generate a random ID to link our FormField label and input component
+  const inputId = useId()
+
   return (
     <FormField
       description={type.description} // Creates description from schema
+      inputId={inputId} // A unique ID for this input
       title={type.title} // Creates label from schema title
       __unstable_markers={markers} // Handles all markers including validation
       __unstable_presence={presence} // Handles presence avatars
     >
-      <ReactMde
-        toolbarCommands={options['toolbar'] || defaultToolbarCommands}
-        value={editedValue}
-        onChange={setEditedValue}
-        selectedTab={selectedTab}
-        onTabChange={setSelectedTab}
-        readOnly={readOnly}
-        generateMarkdownPreview={(markdown) => Promise.resolve(<Preview markdown={markdown} />)}
-        childProps={{
-          writeButton: {
-            tabIndex: -1,
-          },
-        }}
-        refs={{textarea: ref}}
-        paste={{saveImage}}
-      />
+      {/*
+        Assign our forwarded ref to a wrapper element.
+
+        Ideally, this should be assigned to the textarea inside <ReactMde /> component.
+        Whilst `react-mde` does allow you to target individual sub-components' refs,
+        it will complain if you try and assign a forwarded ref.
+      */}
+      <div ref={ref}>
+        <ReactMde
+          toolbarCommands={options['toolbar'] || defaultToolbarCommands}
+          value={editedValue}
+          onChange={setEditedValue}
+          selectedTab={selectedTab}
+          onTabChange={setSelectedTab}
+          readOnly={readOnly}
+          generateMarkdownPreview={(markdown) => Promise.resolve(<Preview markdown={markdown} />)}
+          childProps={{
+            textArea: {
+              id: inputId,
+              onBlur,
+              onFocus,
+            },
+            writeButton: {
+              tabIndex: -1,
+            },
+          }}
+          paste={{saveImage}}
+          refs={{textarea}}
+        />
+      </div>
     </FormField>
   )
 })


### PR DESCRIPTION
1. Conditionally style textarea based on `readOnly` status (refs #22). 
2. Passthrough `onFocus` to `<ReactMde />` textarea sub-component, and pass forwarded ref to wrapper component (refs #21). 
3. Link `<ReactMde />` textarea to `<FormField />` label –  clicking the field label will focus the markdown editor, consistent with how other inputs in the studio work