### PR TITLE
fix: selected text color

### DIFF
--- a/src/components/MarkdownInputStyles.tsx
+++ b/src/components/MarkdownInputStyles.tsx
@@ -18,7 +18,7 @@ export const MarkdownInputStyles = styled(Box)`
   }
 
   & .CodeMirror-focused .CodeMirror-selected.CodeMirror-selected.CodeMirror-selected {
-    background-color: ${({theme}) => theme.sanity.color.selectable.primary.hovered.bg};
+    background-color: ${({theme}) => theme.sanity.color.input.default.disabled.fg};
   }
 
   & .CodeMirror-selected.CodeMirror-selected.CodeMirror-selected {


### PR DESCRIPTION
The selected text color (`theme.sanity.color.selectable.primary.hovered.bg`) was causing the editor to completely crash. 

I assume its because of the transition to the new UI, but this fix should be enough for now.