### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       "peerDependencies": {
         "easymde": "^2.18",
         "react": "^18.3 || ^19",
-        "sanity": "^3.23",
+        "sanity": "^3.23 || ^4.0.0-0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "peerDependencies": {
     "easymde": "^2.18",
     "react": "^18.3 || ^19",
-    "sanity": "^3.23",
+    "sanity": "^3.23 || ^4.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {


### PR DESCRIPTION

### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```json
{
  "dependencies": {
    "sanity": "4.0.0-0"
  }
}
```
Running `pnpm install --resolution-only` yields peer dep issues:
```bash
Progress: resolved 1038, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ sanity-plugin-markdown 5.1.1
  └── ✕ unmet peer sanity@^3.23: found 4.0.0-0
Done in 4.7s using pnpm v10.12.1
```
This fixes it.

### Testing

Tested locally